### PR TITLE
UglifyJS compatability

### DIFF
--- a/voir.js
+++ b/voir.js
@@ -52,12 +52,12 @@
           }
         };
 
-        let isStarted = false;
-        let isJump = false;
+        const isStarted = false;
+        const isJump = false;
 
         if(window && window.__REDUX_DEVTOOLS_EXTENSION__){
           const devTools = window.__REDUX_DEVTOOLS_EXTENSION__.connect();
-          devTools.subscribe((message) => {
+          devTools.subscribe(function(message) {
             if (message.type === 'START') {
               isStarted = true;
               var state = JSON.parse(JSON.stringify(ret.getState()));
@@ -76,7 +76,7 @@
             }
           });
 
-          ret.subscribe((action,state) => {
+          ret.subscribe(function(action,state) {
             if (!isStarted) return;
             var state = JSON.parse(JSON.stringify(ret.getState()));
             action.type = action.type+(action.message?(":"+action.message):"")


### PR DESCRIPTION
UglifyJS don't like the arrow function or the let:
```
ERROR in js/vendor.js from UglifyJs
SyntaxError: Unexpected token: name (isStarted) [js/vendor.js:33576,12]
```
This would make it compatable with the Quasar Framework build tool.